### PR TITLE
Add href link

### DIFF
--- a/src/components/footer/footer.js
+++ b/src/components/footer/footer.js
@@ -31,7 +31,7 @@ export function Footer() {
         {filterTitles.map(filterTitle => (
           <li key={filterTitle.key}>
             <a
-              href="#"
+              href="./#"
               className={classNames({ selected: filterTitle.key === filter })}
               onClick={() => filterSelect(filterTitle.key)}
             >


### PR DESCRIPTION
To remove eslint warning
./src/components/footer/footer.js
  Line 33:13:  The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid